### PR TITLE
feat: Implement Synapse UI renderer from JSON schema

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,2 +1,3 @@
 pub mod atoms;
 pub mod settings;
+pub mod synapse;

--- a/src/components/synapse/mod.rs
+++ b/src/components/synapse/mod.rs
@@ -1,0 +1,6 @@
+// src/components/synapse/mod.rs
+pub mod renderer;
+pub mod schema_parser;
+
+// Optional: Re-export key functions or structs if needed later
+// pub use renderer::render_ui_from_schema;

--- a/src/components/synapse/renderer.rs
+++ b/src/components/synapse/renderer.rs
@@ -1,0 +1,414 @@
+// src/components/synapse/renderer.rs
+use dioxus::prelude::*;
+use crate::components::synapse::schema_parser::{RootSchema, UiElement, Atom, Layout, LayoutElement}; // Ensure LayoutElement is imported
+
+// Main entry point for rendering UI from a JSON schema string
+pub fn render_ui_from_schema(cx: Scope, schema_json: &str) -> Element {
+    match serde_json::from_str::<RootSchema>(schema_json) {
+        Ok(root_schema) => {
+            let rendered_elements = root_schema.ui_elements.into_iter().map(|element| {
+                match element {
+                    UiElement::Atom(atom) => render_atom(cx, atom),
+                    UiElement::Layout(layout) => render_layout(cx, layout),
+                }
+            }).collect::<Vec<Element>>();
+
+            cx.render(rsx! {
+                for element in rendered_elements {
+                    element
+                }
+            })
+        }
+        Err(e) => {
+            eprintln!("Error parsing schema JSON: {:?}", e);
+            None
+        }
+    }
+}
+
+// Implementation for render_atom function
+fn render_atom(cx: Scope, atom: Atom) -> Element {
+    match atom.type_name.as_str() {
+        "label" => {
+            if let Some(text_value_json) = atom.properties.get("text") {
+                if let Some(text_str) = text_value_json.as_str() {
+                    cx.render(rsx!( label { "{text_str}" } ))
+                } else {
+                    eprintln!("Warning: Atom 'label' has 'text' property but it's not a string. Atom: {:?}", atom);
+                    None
+                }
+            } else {
+                eprintln!("Warning: Atom 'label' is missing 'text' property. Atom: {:?}", atom);
+                None
+            }
+        }
+        "portal" => { 
+            cx.render(rsx!( div {} ))
+        }
+        "separator" => {
+            cx.render(rsx!( hr {} ))
+        }
+        "checkbox" | "switch" => {
+            let class_name = if atom.type_name == "switch" { Some("switch") } else { None };
+
+            let checked_attr = atom.properties.get("checked").and_then(|v| v.as_bool());
+            let disabled_attr = atom.properties.get("disabled").and_then(|v| v.as_bool());
+            let value_attr = atom.properties.get("value").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let id_attr = atom.properties.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+
+            cx.render(rsx!(input {
+                r#type: "checkbox",
+                class: class_name,
+                checked: checked_attr,
+                disabled: disabled_attr,
+                value: value_attr.map(|s| format_args!("{}", s)),
+                id: id_attr.map(|s| format_args!("{}", s)),
+            }))
+        }
+        "avatar" => {
+            let src_attr = atom.properties.get("src").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let alt_attr = atom.properties.get("alt").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let size_attr = atom.properties.get("size").and_then(|v| v.as_u64()); // u64 for size
+
+            if src_attr.is_none() {
+                eprintln!("Warning: Atom 'avatar' is missing 'src' property. Atom: {:?}", atom);
+                // Potentially render a placeholder or nothing
+            }
+            
+            cx.render(rsx!(img {
+                src: src_attr.map(|s| format_args!("{}", s)),
+                alt: alt_attr.map(|s| format_args!("{}", s)),
+                width: size_attr.map(|s| format_args!("{}px", s)), // Dioxus might prefer numbers directly for some attributes
+                height: size_attr.map(|s| format_args!("{}px", s)), // but px formatting is safer for style-like attributes
+            }))
+        }
+        "progress" => {
+            // HTML progress element usually takes value as number, not string.
+            // Dioxus should handle Option<f64> or Option<u64> for numeric attributes.
+            let value_attr = atom.properties.get("value").and_then(|v| v.as_f64());
+            let max_attr = atom.properties.get("max").and_then(|v| v.as_f64());
+
+            cx.render(rsx!(progress {
+                value: value_attr,
+                max: max_attr,
+            }))
+        }
+        "slider" => {
+            let value_attr = atom.properties.get("value").and_then(|v| v.as_f64());
+            let min_attr = atom.properties.get("min").and_then(|v| v.as_f64());
+            let max_attr = atom.properties.get("max").and_then(|v| v.as_f64());
+            let step_attr = atom.properties.get("step").and_then(|v| v.as_f64());
+            let disabled_attr = atom.properties.get("disabled").and_then(|v| v.as_bool());
+            let id_attr = atom.properties.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+
+            cx.render(rsx!(input {
+                r#type: "range",
+                value: value_attr,
+                min: min_attr,
+                max: max_attr,
+                step: step_attr,
+                disabled: disabled_attr,
+                id: id_attr.map(|s| format_args!("{}",s)),
+            }))
+        }
+        unknown_type => {
+            eprintln!("Warning: Unknown atom type encountered: {}. Atom: {:?}", unknown_type, atom);
+            None
+        }
+    }
+}
+
+// Implementation for render_layout function
+fn render_layout(cx: Scope, layout: Layout) -> Element {
+    match layout.layout_type.as_str() {
+        "grid" => {
+            let mut container_style_parts: Vec<String> = vec![
+                "display: grid;".to_string(),
+                format!("grid-template-rows: repeat({}, 1fr);", layout.rows),
+                format!("grid-template-columns: repeat({}, 1fr);", layout.cols),
+            ];
+
+            if let Some(gap) = layout.gap {
+                container_style_parts.push(format!("gap: {}px;", gap));
+            }
+            if let Some(padding) = layout.padding {
+                container_style_parts.push(format!("padding: {}px;", padding));
+            }
+            let container_style_str = container_style_parts.join(" ");
+
+            let cells = layout.elements.into_iter().map(|element_config: LayoutElement| {
+                let cell_style_str = format!(
+                    "grid-row-start: {}; grid-column-start: {}; grid-row-end: span {}; grid-column-end: span {};",
+                    element_config.row,
+                    element_config.col,
+                    element_config.row_span, 
+                    element_config.col_span  
+                );
+                let atom_element = render_atom(cx, element_config.atom); 
+                
+                rsx! {
+                    div {
+                        style: "{cell_style_str}",
+                        key: "{element_config.row}-{element_config.col}", 
+                        atom_element
+                    }
+                }
+            }).collect::<Vec<Element>>();
+
+            cx.render(rsx! {
+                div {
+                    style: "{container_style_str}",
+                    cells.into_iter() 
+                }
+            })
+        }
+        unsupported_layout => {
+            eprintln!("Warning: Unsupported layout type: {}", unsupported_layout);
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::synapse::schema_parser::LayoutElement; 
+    use std::collections::HashMap; // For creating properties in tests
+
+    fn render_to_html_string(element_closure: impl FnOnce(Scope) -> Element + 'static) -> String {
+        let mut dom = VirtualDom::new(element_closure);
+        dom.rebuild_to_vec(); 
+        dioxus::ssr::render_lazy(&mut dom)
+    }
+    
+    // --- render_atom tests (existing) ---
+    #[test]
+    fn test_render_label_atom_correctly() {
+        let atom = Atom {
+            type_name: "label".to_string(),
+            properties: [("text".to_string(), serde_json::Value::String("Hello Dioxus".to_string()))].into(),
+        };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), "<label>Hello Dioxus</label>");
+    }
+    #[test]
+    fn test_render_label_atom_missing_text() {
+        let atom = Atom { type_name: "label".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), "<!---->");
+    }
+    #[test]
+    fn test_render_label_atom_wrong_text_type() {
+        let atom = Atom { type_name: "label".to_string(), properties: [("text".to_string(), serde_json::Value::Number(123.into()))].into() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), "<!---->");
+    }
+    #[test]
+    fn test_render_portal_atom() {
+        let atom = Atom { type_name: "portal".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), "<div></div>");
+    }
+    #[test]
+    fn test_render_separator_atom() {
+        let atom = Atom { type_name: "separator".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), "<hr/>");
+    }
+    #[test]
+    fn test_render_unknown_atom_type() {
+        let atom = Atom { type_name: "unknownAtom".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), "<!---->");
+    }
+
+    // --- New render_atom tests ---
+
+    // Checkbox Tests
+    #[test]
+    fn test_render_checkbox_basic() {
+        let atom = Atom { type_name: "checkbox".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="checkbox"/>"#);
+    }
+    #[test]
+    fn test_render_checkbox_checked() {
+        let atom = Atom { type_name: "checkbox".to_string(), properties: [("checked".to_string(), serde_json::Value::Bool(true))].into() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="checkbox" checked="true"/>"#);
+    }
+    #[test]
+    fn test_render_checkbox_all_props() {
+        let props = [
+            ("checked".to_string(), serde_json::Value::Bool(true)),
+            ("disabled".to_string(), serde_json::Value::Bool(true)),
+            ("value".to_string(), serde_json::Value::String("val1".to_string())),
+            ("id".to_string(), serde_json::Value::String("chk1".to_string())),
+        ].into_iter().collect();
+        let atom = Atom { type_name: "checkbox".to_string(), properties: props };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="checkbox" checked="true" disabled="true" value="val1" id="chk1"/>"#);
+    }
+
+    // Switch Tests (renders as checkbox with class "switch")
+    #[test]
+    fn test_render_switch_basic() {
+        let atom = Atom { type_name: "switch".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="checkbox" class="switch"/>"#);
+    }
+    #[test]
+    fn test_render_switch_checked_and_id() {
+        let props = [
+            ("checked".to_string(), serde_json::Value::Bool(true)),
+            ("id".to_string(), serde_json::Value::String("sw1".to_string())),
+        ].into_iter().collect();
+        let atom = Atom { type_name: "switch".to_string(), properties: props };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="checkbox" class="switch" checked="true" id="sw1"/>"#);
+    }
+    
+    // Avatar Tests
+    #[test]
+    fn test_render_avatar_basic() { // Missing src will render img tag but src might be missing or empty
+        let atom = Atom { type_name: "avatar".to_string(), properties: [("alt".to_string(), serde_json::Value::String("User Avatar".to_string()))].into() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<img alt="User Avatar"/>"#);
+    }
+    #[test]
+    fn test_render_avatar_with_src_alt_size() {
+        let props = [
+            ("src".to_string(), serde_json::Value::String("image.png".to_string())),
+            ("alt".to_string(), serde_json::Value::String("User".to_string())),
+            ("size".to_string(), serde_json::json!(32_u64)), // Use u64 for size
+        ].into_iter().collect();
+        let atom = Atom { type_name: "avatar".to_string(), properties: props };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<img src="image.png" alt="User" width="32px" height="32px"/>"#);
+    }
+
+    // Progress Tests
+    #[test]
+    fn test_render_progress_basic() {
+        let atom = Atom { type_name: "progress".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<progress></progress>"#);
+    }
+    #[test]
+    fn test_render_progress_with_value_max() {
+        let props = [
+            ("value".to_string(), serde_json::json!(0.5_f64)),
+            ("max".to_string(), serde_json::json!(1.0_f64)),
+        ].into_iter().collect();
+        let atom = Atom { type_name: "progress".to_string(), properties: props };
+        // Dioxus SSR renders number attributes directly.
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<progress value="0.5" max="1"></progress>"#);
+    }
+    
+    // Slider Tests
+    #[test]
+    fn test_render_slider_basic() {
+        let atom = Atom { type_name: "slider".to_string(), properties: HashMap::new() };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="range"/>"#);
+    }
+    #[test]
+    fn test_render_slider_all_props() {
+        let props = [
+            ("value".to_string(), serde_json::json!(50_f64)),
+            ("min".to_string(), serde_json::json!(0_f64)),
+            ("max".to_string(), serde_json::json!(100_f64)),
+            ("step".to_string(), serde_json::json!(1_f64)),
+            ("disabled".to_string(), serde_json::Value::Bool(false)), // Note: disabled="false" is not rendered by browsers
+            ("id".to_string(), serde_json::Value::String("sl1".to_string())),
+        ].into_iter().collect();
+        let atom = Atom { type_name: "slider".to_string(), properties: props };
+        // Dioxus SSR for boolean attributes: if Some(false), it might omit it or render as "false".
+        // Standard HTML behavior: presence of `disabled` means true, absence means false.
+        // Dioxus typically omits boolean attributes if they are false.
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="range" value="50" min="0" max="100" step="1" id="sl1"/>"#);
+    }
+     #[test]
+    fn test_render_slider_disabled_true() {
+        let props = [
+            ("disabled".to_string(), serde_json::Value::Bool(true)),
+        ].into_iter().collect();
+        let atom = Atom { type_name: "slider".to_string(), properties: props };
+        assert_eq!(render_to_html_string(|cx| render_atom(cx, atom.clone())), r#"<input type="range" disabled="true"/>"#);
+    }
+
+
+    // --- render_layout tests (existing) ---
+    #[test]
+    fn test_render_simple_grid_layout() {
+        let layout = Layout {
+            layout_type: "grid".to_string(), rows: 1, cols: 1, gap: Some(10), padding: Some(5),
+            elements: vec![ LayoutElement {
+                    atom: Atom { type_name: "label".to_string(), properties: [("text".to_string(), serde_json::Value::String("Cell1".to_string()))].into() },
+                    row: 1, col: 1, row_span: 1, col_span: 1,
+                }]};
+        let expected_html = r#"<div style="display: grid; grid-template-rows: repeat(1, 1fr); grid-template-columns: repeat(1, 1fr); gap: 10px; padding: 5px;"><div style="grid-row-start: 1; grid-column-start: 1; grid-row-end: span 1; grid-column-end: span 1;" key="1-1"><label>Cell1</label></div></div>"#;
+        assert_eq!(render_to_html_string(|cx| render_layout(cx, layout.clone())), expected_html);
+    }
+    #[test]
+    fn test_render_grid_layout_no_gap_padding() {
+        let layout = Layout {
+            layout_type: "grid".to_string(), rows: 1, cols: 1, gap: None, padding: None,
+            elements: vec![ LayoutElement {
+                    atom: Atom { type_name: "label".to_string(), properties: [("text".to_string(), serde_json::Value::String("Cell1".to_string()))].into() },
+                    row: 1, col: 1, row_span: 1, col_span: 1,
+                }]};
+        let expected_html = r#"<div style="display: grid; grid-template-rows: repeat(1, 1fr); grid-template-columns: repeat(1, 1fr);"><div style="grid-row-start: 1; grid-column-start: 1; grid-row-end: span 1; grid-column-end: span 1;" key="1-1"><label>Cell1</label></div></div>"#;
+        assert_eq!(render_to_html_string(|cx| render_layout(cx, layout.clone())), expected_html);
+    }
+    #[test]
+    fn test_render_grid_layout_with_spanning() {
+        let layout = Layout {
+            layout_type: "grid".to_string(), rows: 2, cols: 2, gap: None, padding: None,
+            elements: vec![ LayoutElement {
+                    atom: Atom { type_name: "label".to_string(), properties: [("text".to_string(), serde_json::Value::String("Span".to_string()))].into() },
+                    row: 1, col: 1, row_span: 2, col_span: 2,
+                }]};
+        let expected_html = r#"<div style="display: grid; grid-template-rows: repeat(2, 1fr); grid-template-columns: repeat(2, 1fr);"><div style="grid-row-start: 1; grid-column-start: 1; grid-row-end: span 2; grid-column-end: span 2;" key="1-1"><label>Span</label></div></div>"#;
+        assert_eq!(render_to_html_string(|cx| render_layout(cx, layout.clone())), expected_html);
+    }
+    #[test]
+    fn test_render_unsupported_layout_type() {
+        let layout = Layout { layout_type: "flexbox".to_string(), rows: 1, cols: 1, gap: None, padding: None, elements: vec![] };
+        assert_eq!(render_to_html_string(|cx| render_layout(cx, layout.clone())), "<!---->"); 
+    }
+    #[test]
+    fn test_render_grid_with_empty_elements() {
+        let layout = Layout { layout_type: "grid".to_string(), rows: 1, cols: 1, gap: None, padding: None, elements: vec![] };
+        let expected_html = r#"<div style="display: grid; grid-template-rows: repeat(1, 1fr); grid-template-columns: repeat(1, 1fr);"></div>"#;
+        assert_eq!(render_to_html_string(|cx| render_layout(cx, layout.clone())), expected_html);
+    }
+
+    // --- render_ui_from_schema tests (existing) ---
+    #[test]
+    fn test_render_schema_with_grid_layout() {
+        let schema_json = r#"
+        { "uiElements": [ { "layoutType": "grid", "rows": 1, "cols": 2, "gap": 5, "elements": [
+            { "atom": {"type": "label", "properties": {"text": "Left"}}, "row": 1, "col": 1 },
+            { "atom": {"type": "label", "properties": {"text": "Right"}}, "row": 1, "col": 2 }
+        ]}]} "#;
+        let expected_html_part1 = r#"<div style="display: grid; grid-template-rows: repeat(1, 1fr); grid-template-columns: repeat(2, 1fr); gap: 5px;"><div style="grid-row-start: 1; grid-column-start: 1; grid-row-end: span 1; grid-column-end: span 1;" key="1-1"><label>Left</label></div>"#;
+        let expected_html_part2 = r#"<div style="grid-row-start: 1; grid-column-start: 2; grid-row-end: span 1; grid-column-end: span 1;" key="1-2"><label>Right</label></div></div>"#;
+        let rendered_html = render_to_html_string(|cx| render_ui_from_schema(cx, schema_json));
+        assert_eq!(rendered_html, format!("{}{}", expected_html_part1, expected_html_part2));
+    }
+    #[test]
+    fn test_render_empty_schema() {
+        let schema_json = r#"{"uiElements": []}"#;
+        assert_eq!(render_to_html_string(|cx| render_ui_from_schema(cx, schema_json)), "<!---->");
+    }
+    #[test]
+    fn test_render_invalid_json() {
+        let schema_json = r#"{"uiElements": [}"#; 
+        assert_eq!(render_to_html_string(|cx| render_ui_from_schema(cx, schema_json)), "<!---->");
+    }
+    #[test]
+    fn test_render_complex_schema_mixed_elements() {
+        let schema_json = r#"
+        { "uiElements": [ { "type": "separator" },
+            { "layoutType": "grid", "rows": 2, "cols": 2, "gap": 5, "padding": 10, "elements": [
+                { "atom": {"type": "label", "properties": {"text": "TopLeft"}}, "row": 1, "col": 1 },
+                { "atom": {"type": "portal"}, "row": 1, "col": 2 },
+                { "atom": {"type": "label", "properties": {"text": "BottomSpan"}}, "row": 2, "col": 1, "colSpan": 2 }
+            ]}]} "#;
+        let rendered_html = render_to_html_string(|cx| render_ui_from_schema(cx, schema_json));
+        let expected_separator_html = "<hr/>";
+        let expected_grid_container_style = "display: grid; grid-template-rows: repeat(2, 1fr); grid-template-columns: repeat(2, 1fr); gap: 5px; padding: 10px;";
+        let expected_cell1_html = format!(r#"<div style="{}" key="1-1">{}</div>"#, "grid-row-start: 1; grid-column-start: 1; grid-row-end: span 1; grid-column-end: span 1;", "<label>TopLeft</label>");
+        let expected_cell2_html = format!(r#"<div style="{}" key="1-2">{}</div>"#, "grid-row-start: 1; grid-column-start: 2; grid-row-end: span 1; grid-column-end: span 1;", "<div></div>");
+        let expected_cell3_html = format!(r#"<div style="{}" key="2-1">{}</div>"#, "grid-row-start: 2; grid-column-start: 1; grid-row-end: span 1; grid-column-end: span 2;", "<label>BottomSpan</label>");
+        let expected_final_html = format!( "{}{}{}{}{}{}{}{}", expected_separator_html, r#"<div style=""#, expected_grid_container_style, r#"">"#, expected_cell1_html, expected_cell2_html, expected_cell3_html, "</div>");
+        assert_eq!(rendered_html, expected_final_html, "Full HTML structure does not match.");
+    }
+}
+```

--- a/src/components/synapse/schema_parser.rs
+++ b/src/components/synapse/schema_parser.rs
@@ -1,0 +1,235 @@
+// src/components/synapse/schema_parser.rs
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RootSchema {
+    pub ui_elements: Vec<UiElement>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+// UiElement is expected to be an untagged enum based on schema structure.
+// The JSON objects for Atom and Layout are structurally distinct.
+// Atom has "type" and "properties".
+// Layout has "layoutType", "rows", "cols", "elements".
+// Serde will try to deserialize into Atom first, and if it fails (e.g., missing "type" field
+// or finding "layoutType" instead), it will try Layout.
+#[serde(untagged)] 
+pub enum UiElement {
+    Atom(Atom),
+    Layout(Layout),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Atom {
+    #[serde(rename = "type")] // Map the schema's "type" to "type_name" in Rust
+    pub type_name: String, 
+    #[serde(default)] // If properties is missing, default to an empty HashMap
+    pub properties: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Layout {
+    pub layout_type: String, // e.g., "grid"
+    pub rows: u32,
+    pub cols: u32,
+    pub gap: Option<u32>,
+    pub padding: Option<u32>,
+    pub elements: Vec<LayoutElement>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LayoutElement {
+    pub atom: Atom,
+    pub row: u32,
+    pub col: u32,
+    #[serde(default = "default_span")]
+    pub row_span: u32,
+    #[serde(default = "default_span")]
+    pub col_span: u32,
+}
+
+fn default_span() -> u32 {
+    1
+}
+
+// Basic test to ensure deserialization works for a simple case (optional, but good practice)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_simple_atom() {
+        let json_data = r#"
+        {
+            "uiElements": [
+                {
+                    "type": "label",
+                    "properties": {
+                        "text": "Hello"
+                    }
+                }
+            ]
+        }
+        "#;
+        let parsed: Result<RootSchema, _> = serde_json::from_str(json_data);
+        assert!(parsed.is_ok(), "Failed to parse simple atom: {:?}", parsed.err());
+        let root_schema = parsed.unwrap();
+        assert_eq!(root_schema.ui_elements.len(), 1);
+        // Check if the first element is an Atom and matches expectations
+        match &root_schema.ui_elements[0] {
+            UiElement::Atom(atom) => {
+                assert_eq!(atom.type_name, "label");
+                assert_eq!(atom.properties.get("text").unwrap().as_str().unwrap(), "Hello");
+            }
+            _ => panic!("Expected an Atom"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_simple_layout() {
+        let json_data = r#"
+        {
+            "uiElements": [
+                {
+                    "layoutType": "grid",
+                    "rows": 1,
+                    "cols": 1,
+                    "elements": [
+                        {
+                            "atom": {
+                                "type": "label",
+                                "properties": {"text": "In Grid"}
+                            },
+                            "row": 1,
+                            "col": 1
+                        }
+                    ]
+                }
+            ]
+        }
+        "#;
+        let parsed: Result<RootSchema, _> = serde_json::from_str(json_data);
+        assert!(parsed.is_ok(), "Failed to parse simple layout: {:?}", parsed.err());
+        let root_schema = parsed.unwrap();
+        assert_eq!(root_schema.ui_elements.len(), 1);
+        // Check if the first element is a Layout and matches expectations
+        match &root_schema.ui_elements[0] {
+            UiElement::Layout(layout) => {
+                assert_eq!(layout.layout_type, "grid");
+                assert_eq!(layout.elements.len(), 1);
+                assert_eq!(layout.elements[0].atom.type_name, "label");
+                assert_eq!(layout.elements[0].row_span, 1); // Check default span
+                assert_eq!(layout.elements[0].col_span, 1); // Check default span
+            }
+            _ => panic!("Expected a Layout"),
+        }
+    }
+    
+    #[test]
+    fn test_deserialize_untagged_choice() {
+        // Test if UiElement can correctly deserialize both Atom and Layout
+        // when they appear in a list.
+        let json_data = r#"
+        {
+            "uiElements": [
+                {
+                    "type": "label",
+                    "properties": { "text": "First Atom" }
+                },
+                {
+                    "layoutType": "grid",
+                    "rows": 1,
+                    "cols": 1,
+                    "elements": [
+                        {
+                            "atom": { "type": "label", "properties": {"text": "Atom in Grid"} },
+                            "row": 1,
+                            "col": 1,
+                            "rowSpan": 2 
+                        }
+                    ]
+                }
+            ]
+        }
+        "#;
+        let parsed: Result<RootSchema, _> = serde_json::from_str(json_data);
+        assert!(parsed.is_ok(), "Failed to parse untagged choice: {:?}", parsed.err());
+        let root_schema = parsed.unwrap();
+        assert_eq!(root_schema.ui_elements.len(), 2);
+
+        match &root_schema.ui_elements[0] {
+            UiElement::Atom(atom) => assert_eq!(atom.type_name, "label"),
+            _ => panic!("Expected first element to be an Atom"),
+        }
+        match &root_schema.ui_elements[1] {
+            UiElement::Layout(layout) => {
+                assert_eq!(layout.layout_type, "grid");
+                assert_eq!(layout.elements[0].row_span, 2); // Explicitly set
+                assert_eq!(layout.elements[0].col_span, 1); // Default
+            }
+            _ => panic!("Expected second element to be a Layout"),
+        }
+    }
+
+    #[test]
+    fn test_atom_missing_properties() {
+        let json_data = r#"
+        {
+            "uiElements": [
+                {
+                    "type": "avatar"
+                }
+            ]
+        }
+        "#;
+        let parsed: Result<RootSchema, _> = serde_json::from_str(json_data);
+        assert!(parsed.is_ok(), "Failed to parse atom with missing properties: {:?}", parsed.err());
+        let root_schema = parsed.unwrap();
+        assert_eq!(root_schema.ui_elements.len(), 1);
+        match &root_schema.ui_elements[0] {
+            UiElement::Atom(atom) => {
+                assert_eq!(atom.type_name, "avatar");
+                assert!(atom.properties.is_empty(), "Properties should be an empty HashMap");
+            }
+            _ => panic!("Expected an Atom"),
+        }
+    }
+
+    #[test]
+    fn test_layout_missing_optional_fields() {
+        let json_data = r#"
+        {
+            "uiElements": [
+                {
+                    "layoutType": "grid",
+                    "rows": 2,
+                    "cols": 2,
+                    "elements": []
+                }
+            ]
+        }
+        "#;
+        let parsed: Result<RootSchema, _> = serde_json::from_str(json_data);
+        assert!(parsed.is_ok(), "Failed to parse layout with missing optional fields: {:?}", parsed.err());
+        let root_schema = parsed.unwrap();
+        assert_eq!(root_schema.ui_elements.len(), 1);
+        match &root_schema.ui_elements[0] {
+            UiElement::Layout(layout) => {
+                assert_eq!(layout.layout_type, "grid");
+                assert_eq!(layout.rows, 2);
+                assert_eq!(layout.cols, 2);
+                assert_eq!(layout.gap, None);
+                assert_eq!(layout.padding, None);
+                assert!(layout.elements.is_empty());
+            }
+            _ => panic!("Expected a Layout"),
+        }
+    }
+}
+```


### PR DESCRIPTION
This commit introduces the Synapse module, capable of rendering Dioxus UI components from a JSON schema (`generative_ui_schema.json`).

Key features:
- **Schema Parsing**: Rust structs defined in `schema_parser.rs` allow for deserializing the JSON schema using `serde`.
- **Main Renderer**: `render_ui_from_schema` in `renderer.rs` is the main entry point, parsing the JSON and orchestrating the rendering of UI elements.
- **Atom Rendering**: The `render_atom` function supports rendering various atomic components:
    - `label` (renders <label>)
    - `portal` (renders <div>)
    - `separator` (renders <hr/>)
    - `checkbox` (renders <input type="checkbox">)
    - `switch` (renders <input type="checkbox" class="switch">)
    - `avatar` (renders <img>)
    - `progress` (renders <progress>)
    - `slider` (renders <input type="range">) It handles common properties for these atoms (e.g., text, checked, src, value, max, etc.).
- **Layout Rendering**: The `render_layout` function supports "grid" layouts, applying inline styles for grid structure, rows, columns, gap, padding, and cell spanning.
- **Error Handling**: The system gracefully handles JSON parsing errors and unknown atom/layout types by rendering nothing for the problematic parts and printing warnings.
- **Comprehensive Tests**: Unit tests cover schema parsing, individual atom rendering with various properties, grid layout rendering (including styling and spanning), and rendering of complex, mixed schemas.

The new module is located in `src/components/synapse/`. This provides a foundational capability for dynamically generating UIs based on a structured schema, potentially driven by an LLM.